### PR TITLE
To build on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,8 @@ Version: 0.0.0.9000
 Authors@R: c(
     person("Andy", "Thomason", , "andy@andythomason.com", c("aut", "cre")),
     person("Claus O.", "Wilke", , "wilke@austin.utexas.edu", "aut",
-      comment = c(ORCID = "0000-0002-7470-9261"))
+      comment = c(ORCID = "0000-0002-7470-9261")),
+    person("Mossa M.", "Reimert", , "mossa@sund.ku.dk", c("aut"))
   )
 Description: Call Rust code from R using the 'extendr' crate
 License: MIT + file LICENSE

--- a/R/source.R
+++ b/R/source.R
@@ -49,7 +49,7 @@ rust_source <- function(file, code = NULL, dependencies = NULL, patch.crates_io 
     args = c(
       "build",
       #"--release",  # release vs debug should be configurable at some point; for now, debug compiles faster
-      sprintf("--manifest-path=%s", file.path(dir, "Cargo.toml"))
+      sprintf("--lib --manifest-path=%s --target-dir %s/target/", file.path(dir, "Cargo.toml"), dir)
     ),
     stdout = stdout,
     stderr = stdout
@@ -67,7 +67,14 @@ rust_source <- function(file, code = NULL, dependencies = NULL, patch.crates_io 
   source(r_path, local = env)
 
   # load shared library
-  shared_lib <- file.path(dir, "target", "debug", paste0("lib", libname, get_dynlib_ext()))
+  libfilename <- if (.Platform$OS.type == "windows") {
+    paste0(libname, get_dynlib_ext())
+  } else {
+    paste0("lib", libname, get_dynlib_ext())
+  }
+
+  # the$shared_lib <- file.path(dir, "target", "debug", libfilename)
+  shared_lib <- file.path(dir, "target", "debug", libfilename)
   dyn.load(shared_lib, local = TRUE, now = TRUE)
 }
 

--- a/R/source.R
+++ b/R/source.R
@@ -48,8 +48,10 @@ rust_source <- function(file, code = NULL, dependencies = NULL, patch.crates_io 
     command = "cargo",
     args = c(
       "build",
+      "--lib",
       #"--release",  # release vs debug should be configurable at some point; for now, debug compiles faster
-      sprintf("--lib --manifest-path=%s --target-dir %s/target/", file.path(dir, "Cargo.toml"), dir)
+      sprintf("--manifest-path %s", file.path(dir, "Cargo.toml")),
+      sprintf("--target-dir %s", file.path(dir, "target"))
     ),
     stdout = stdout,
     stderr = stdout
@@ -73,7 +75,6 @@ rust_source <- function(file, code = NULL, dependencies = NULL, patch.crates_io 
     paste0("lib", libname, get_dynlib_ext())
   }
 
-  # the$shared_lib <- file.path(dir, "target", "debug", libfilename)
   shared_lib <- file.path(dir, "target", "debug", libfilename)
   dyn.load(shared_lib, local = TRUE, now = TRUE)
 }


### PR DESCRIPTION
Change the lib-name without the prefix.
Specify the location of targets in the temporary folder.

Add "--lib" flag for insurance.

See #2 for discussion.